### PR TITLE
Fixed CSS + image rendering errors

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <title>Document</title>
-    <link rel="stylesheet" type="text/css" href="/css/main.css"/>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
+    <link rel="stylesheet" type="text/css" href="css/main.css"/>
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css">
     <link href="https://fonts.googleapis.com/css?family=Lobster" rel="stylesheet" type="text/css">
 </head>
 <body>
@@ -18,7 +18,7 @@
         </div>
         <div id="img-div">
                 <figure>
-        <img id="image" src="/images/10613180113_fdf7bcd316_b.jpg" alt="Tenderness">
+        <img id="image" src="images/10613180113_fdf7bcd316_b.jpg" alt="Tenderness">
         <figcaption id="img-caption">
             Dr. Norman Borlaug, third from the left, trains biologists in Mexico on how to increase wheat yields - part of his life-long war on hunger.
         </figcaption>


### PR DESCRIPTION
I fixed the formatting problem with CSS and the image file (which is now hosted directly on this web server; the hyperlink to it is gone) - I just had to delete a forward slash from the **href** path, as you can see in the edit history below, lol.

Your hosted website was giving some crap about the Bootstrap integrity algorithm being unable to work, so I deleted the integrity check; now it doesn't even try (which makes things simpler - this project doesn't require it).


![](https://i.ytimg.com/vi/x0pmc35Rwa0/maxresdefault.jpg)
